### PR TITLE
🐛 fix: 페이지 이동 후 필터 선택할 때, 페이지가 초기화되지 않는 오류 수정

### DIFF
--- a/src/pages/meet/index.tsx
+++ b/src/pages/meet/index.tsx
@@ -33,6 +33,7 @@ const MeetPage = () => {
   const router = useRouter()
   const queryClient = useQueryClient()
   const { page, size, location, type } = currentQueryString
+
   useEffect(() => {
     if (currentQueryString.page < data?.data?.totalPages) {
       queryClient.prefetchQuery(
@@ -66,6 +67,7 @@ const MeetPage = () => {
               handleSelected={(filter) =>
                 setCurrentQueryString({
                   ...currentQueryString,
+                  page: 0,
                   location: filter,
                 })
               }
@@ -73,7 +75,11 @@ const MeetPage = () => {
             <FilterButton
               type="meet"
               handleSelected={(filter) =>
-                setCurrentQueryString({ ...currentQueryString, type: filter })
+                setCurrentQueryString({
+                  ...currentQueryString,
+                  page: 0,
+                  type: filter,
+                })
               }
             />
           </div>

--- a/src/pages/performance/index.tsx
+++ b/src/pages/performance/index.tsx
@@ -140,6 +140,7 @@ const PerformancePage = () => {
             handleSelected={(region) =>
               setPerformancePayload({
                 ...performancePayload,
+                pageNumber: 0,
                 location: region as RegionTypes,
               })
             }
@@ -150,6 +151,7 @@ const PerformancePage = () => {
               handleSelected={(genre) =>
                 setPerformancePayload({
                   ...performancePayload,
+                  pageNumber: 0,
                   genre: genre as GenreTypes,
                 })
               }


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약
<!-- 무엇을 구현하였는지 요약해주세요. -->
# 사진 (구현 캡처)

# 작업 내용
<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->
- [x] [🐛 fix: 페이지 이동 후 필터 선택할 때, 페이지가 초기화되지 않는 오류 수정](https://github.com/dnd-side-project/dnd-8th-1-frontend/commit/44ff7ec80bb0866ca079633581864850a6a02180)


# 기타 (논의하고 싶은 부분)
 페이지 이동 후 필터 선택했을 때 데이터 잘 들어오는지 확인해보시면 됩니다 (만나기 메인, 공연 메인)
 중요한건 아니지만, 원래는 페이지 잘못 전달하면 에러 응답이 돌아왔었는데, 백엔드에서 잠수함 패치를 한건지 이제 에러는 안들어오고 빈배열로 들어오더라고요!
 
# 타 직군 전달 사항

## 백엔드 전달 사항

## 디자이너 전달 사항

close #344 
